### PR TITLE
Document build_ext --inplace before testing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Running the test suite
 To run the test suite, you need nosetests and the coverage modules.
 Run the test suite using::
 
-    nosetests
+    python setup.py build_ext --inplace && nosetests
 
 from the root of the project.
 


### PR DESCRIPTION
Otherwise we get a "ImportError: cannot import name _hmmc".
