### PR TITLE
self._covars_ in GaussianHMM is not writeable when settin n_components=1

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Authors and contributors, in no particular order:
 * csytracy
 * Alexandre Gramfort
 * Sergei Lebedev
+* Daniela Huppenkothen

--- a/hmmlearn/hmm.py
+++ b/hmmlearn/hmm.py
@@ -191,7 +191,9 @@ class GaussianHMM(_BaseHMM):
                 cv.shape = (1, 1)
             self._covars_ = distribute_covar_matrix_to_match_covariance_type(
                 cv, self.covariance_type, self.n_components)
-            self._covars_[self._covars_ == 0] = 1e-5
+            self._covars_ = self._covars_.copy()
+            if self._covars_.any() == 0:
+                self._covars_[self._covars_ == 0] = 1e-5
 
     def _initialize_sufficient_statistics(self):
         stats = super(GaussianHMM, self)._initialize_sufficient_statistics()

--- a/hmmlearn/tests/test_hmm.py
+++ b/hmmlearn/tests/test_hmm.py
@@ -218,6 +218,12 @@ class TestGaussianHMMWithSphericalCovars(GaussianHMMTestMixin, TestCase):
 class TestGaussianHMMWithDiagonalCovars(GaussianHMMTestMixin, TestCase):
     covariance_type = 'diag'
 
+    def test_covar_is_writeable(self):        
+        h = hmm.GaussianHMM(n_components=1, covariance_type='diag')
+        X = np.random.normal(size=(1000,5))
+        h._init(X, params="c")
+        assert h._covars_.flags["WRITEABLE"] is True, \
+               "Covars is not writeable due to numpy.diag behaviour in numpy >=1.9"
 
 class TestGaussianHMMWithTiedCovars(GaussianHMMTestMixin, TestCase):
     covariance_type = 'tied'


### PR DESCRIPTION
For a GaussianHMM with n_components=1 and covariance_type="diag", the last line in GaussianHMM._init throws a ValueError, because self._covars_ is not writeable (flags.["WRITEABLE"]=False). 

This is caused by the use of numpy.diag in sklearn.mixture.distribute_covar_matrix_to_match_covariance_type, which returns a read-only numpy.ndarray. This is intended behaviour for numpy 1.9 (see http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.diagonal.html). As per the recommendation in the documentation, setting self._covars_ to a copy of itself fixes the issue and makes behaviour consistent across current and future versions of numpy.