### PR TITLE
adding numpy as dependency (fixes pip installation)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ import hmmlearn
 
 VERSION = hmmlearn.__version__
 
-install_requires = ["scikit-learn>=0.16"]
+install_requires = ["numpy", "scikit-learn>=0.16"]
 tests_require = install_requires + ["pytest"]
 docs_require = install_requires + [
     "Sphinx", "sphinx-gallery", "numpydoc", "Pillow", "matplotlib"


### PR DESCRIPTION
Pip installation fails if numpy is not present. I imagine also easy_install fails.