### PR TITLE
Fix #214

### DIFF
--- a/hmmlearn/base.py
+++ b/hmmlearn/base.py
@@ -11,7 +11,7 @@ from sklearn.utils import check_array, check_random_state
 from sklearn.utils.validation import check_is_fitted
 
 from . import _hmmc
-from .utils import normalize, log_normalize, iter_from_X_lengths, log_mask_zero
+from .utils import normalize, log_normalize, iter_from_X_lengths
 
 
 #: Supported decoder algorithms.
@@ -451,16 +451,16 @@ class _BaseHMM(BaseEstimator):
     def _do_viterbi_pass(self, framelogprob):
         n_samples, n_components = framelogprob.shape
         state_sequence, logprob = _hmmc._viterbi(
-            n_samples, n_components, log_mask_zero(self.startprob_),
-            log_mask_zero(self.transmat_), framelogprob)
+            n_samples, n_components, np.log(self.startprob_),
+            np.log(self.transmat_), framelogprob)
         return logprob, state_sequence
 
     def _do_forward_pass(self, framelogprob):
         n_samples, n_components = framelogprob.shape
         fwdlattice = np.zeros((n_samples, n_components))
         _hmmc._forward(n_samples, n_components,
-                       log_mask_zero(self.startprob_),
-                       log_mask_zero(self.transmat_),
+                       np.log(self.startprob_),
+                       np.log(self.transmat_),
                        framelogprob, fwdlattice)
         return logsumexp(fwdlattice[-1]), fwdlattice
 
@@ -468,8 +468,8 @@ class _BaseHMM(BaseEstimator):
         n_samples, n_components = framelogprob.shape
         bwdlattice = np.zeros((n_samples, n_components))
         _hmmc._backward(n_samples, n_components,
-                        log_mask_zero(self.startprob_),
-                        log_mask_zero(self.transmat_),
+                        np.log(self.startprob_),
+                        np.log(self.transmat_),
                         framelogprob, bwdlattice)
         return bwdlattice
 
@@ -624,7 +624,7 @@ class _BaseHMM(BaseEstimator):
 
             log_xi_sum = np.full((n_components, n_components), -np.inf)
             _hmmc._compute_log_xi_sum(n_samples, n_components, fwdlattice,
-                                      log_mask_zero(self.transmat_),
+                                      np.log(self.transmat_),
                                       bwdlattice, framelogprob,
                                       log_xi_sum)
             stats['trans'] += np.exp(log_xi_sum)

--- a/hmmlearn/tests/test_bug.py
+++ b/hmmlearn/tests/test_bug.py
@@ -1,0 +1,29 @@
+# Bug-specific tests
+
+from hmmlearn import hmm
+import numpy as np
+
+def test_214():
+    model = hmm.GaussianHMM(
+        n_components=3, params='st', init_params='',
+    )
+
+    model.transmat_ = np.array(
+        [[0.8, 0.1, 0.1],
+        [0.1, 0.9, 0.0],
+        [0.0, 0.0, 1.0]]
+    )
+    model.means_ = np.array([1.0, 0.0, 0.0]).reshape(-1, 1)
+    model.covars_ = np.array([0.001, 0.001, 0.001]).reshape(-1, 1)
+    model.startprob_ = np.array([0.8, 0.1, 0.1])
+
+    samples = np.array([
+        0.97463307, 0.98580524, 0.96502726, 0.94767963, 0.96783919, 0.02015515,
+        0.97280737, 1.05605478, 1.01784615, -0.01791463, 0.02308386, 0.0117951,
+        0.01688058, -0.00290845, 0.03611139, -0.03572094, -0.02688102, 0.0303838,
+        0.02761991, -0.00352225
+    ]).reshape(-1, 1)
+    states = [0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+
+    prediction = model.predict(samples)
+    np.testing.assert_equal(states, prediction)

--- a/hmmlearn/utils.py
+++ b/hmmlearn/utils.py
@@ -62,24 +62,6 @@ def iter_from_X_lengths(X, lengths):
             yield start[i], end[i]
 
 
-def log_mask_zero(a):
-    """Computes the log of input probabilities masking divide by zero in log.
-
-    Notes
-    -----
-    During the M-step of EM-algorithm, very small intermediate start
-    or transition probabilities could be normalized to zero, causing a
-    *RuntimeWarning: divide by zero encountered in log*.
-
-    This function masks this unharmful warning.
-    """
-    a = np.asarray(a)
-    with np.errstate(divide="ignore"):
-        a_log = np.log(a)
-        a_log[a <= 0] = 0.0
-        return a_log
-
-
 def fill_covars(covars, covariance_type='full', n_components=1, n_features=1):
     if covariance_type == 'full':
         return covars


### PR DESCRIPTION
Revert the addition of `log_mask_zero`, since it breaks model prediction. I understand the warning is annoying, but the breakage is worse, so it should be re-done now there is a test in place.

Note this includes the changes of #213, as that is my local master, but could be re-based if necessary.