### PR TITLE
BUG in ``log_mask_zero``: log(0) = -inf

### DIFF
--- a/hmmlearn/utils.py
+++ b/hmmlearn/utils.py
@@ -76,7 +76,7 @@ def log_mask_zero(a):
     a = np.asarray(a)
     with np.errstate(divide="ignore"):
         a_log = np.log(a)
-        a_log[a <= 0] = 0.0
+        a_log[a <= 0] = -np.inf
         return a_log
 
 

--- a/hmmlearn/utils.py
+++ b/hmmlearn/utils.py
@@ -75,9 +75,7 @@ def log_mask_zero(a):
     """
     a = np.asarray(a)
     with np.errstate(divide="ignore"):
-        a_log = np.log(a)
-        a_log[a <= 0] = -np.inf
-        return a_log
+        return np.log(a)
 
 
 def fill_covars(covars, covariance_type='full', n_components=1, n_features=1):


### PR DESCRIPTION
Commit f66a053e7f6b1081f000cd871b73b04ea4a62433 introduced masking of
probabilities that are zero to avoid run-time warning of their logarithm.
It was assumed that the log(x) is 0 for x <= 0. But this corresponds to
x = 1. The right value is -inf for x = 0.

This fix sets log(0) = -inf. Additionally, all values of log(x) for
x < 0 are also set to -inf, which is reasonable considering that x is a
probability and should not be smaller than 0 in the first place.