### PR TITLE
add a deprecated sklearn function to utils

### DIFF
--- a/hmmlearn/hmm.py
+++ b/hmmlearn/hmm.py
@@ -13,14 +13,12 @@ The :mod:`hmmlearn.hmm` module implements hidden Markov models.
 import numpy as np
 from scipy.misc import logsumexp
 from sklearn import cluster
-from sklearn.mixture import (
-    distribute_covar_matrix_to_match_covariance_type, _validate_covars
-)
+from sklearn.mixture import _validate_covars
 from sklearn.utils import check_random_state
 
 from .stats import log_multivariate_normal_density
 from .base import _BaseHMM
-from .utils import iter_from_X_lengths, normalize, fill_covars
+from .utils import iter_from_X_lengths, normalize, fill_covars, distribute_covar_matrix_to_match_covariance_type
 
 __all__ = ["GMMHMM", "GaussianHMM", "MultinomialHMM"]
 

--- a/hmmlearn/utils.py
+++ b/hmmlearn/utils.py
@@ -91,3 +91,21 @@ def fill_covars(covars, covariance_type='full', n_components=1, n_features=1):
         eye = np.eye(n_features)[np.newaxis, :, :]
         covars = covars[:, np.newaxis, np.newaxis]
         return eye * covars
+
+
+def distribute_covar_matrix_to_match_covariance_type(
+        tied_cv, covariance_type, n_components):
+    """Create all the covariance matrices from a given template."""
+    if covariance_type == 'spherical':
+        cv = np.tile(tied_cv.mean() * np.ones(tied_cv.shape[1]),
+                     (n_components, 1))
+    elif covariance_type == 'tied':
+        cv = tied_cv
+    elif covariance_type == 'diag':
+        cv = np.tile(np.diag(tied_cv), (n_components, 1))
+    elif covariance_type == 'full':
+        cv = np.tile(tied_cv, (n_components, 1, 1))
+    else:
+        raise ValueError("covariance_type must be one of " +
+                         "'spherical', 'tied', 'diag', 'full'")
+    return cv


### PR DESCRIPTION
add a local copy of distribute_covar_matrix_to_match_covariance_type to utils.py since it is deprecated in sklearn.