### PR TITLE
TST: fix pytest command on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"import pytest; pytest.main()\" -s -v hmmlearn"
+  - "python -c \"import pytest; pytest.main()\" -s -v --pyargs hmmlearn"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"import pytest; pytest.main()\" -s -v --pyargs hmmlearn"
+  - "python -c \"from os.path import dirname; import pytest; import hmmlearn; pytest.main([dirname(hmmlearn.__file__), \"-s\", \"-v\"])\""
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"from os.path import dirname; import pytest; import hmmlearn; pytest.main([dirname(hmmlearn.__file__), \"-s\", \"-v\"])\""
+  - "python -c \"from os.path import dirname; import pytest; import hmmlearn; pytest.main([dirname(hmmlearn.__file__), '-s', '-v'])\""
 
   # Move back to the project folder
   - "cd .."

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -9,8 +9,8 @@
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
 pytest
-numpy==1.9.3
-scipy==0.16.0
+numpy
+scipy==0.19.0
 scikit-learn
 wheel
 wheelhouse_uploader

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -9,7 +9,7 @@
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
 pytest
-numpy
+numpy==1.13.0
 scipy==0.19.0
 scikit-learn
 wheel

--- a/hmmlearn/tests/__init__.py
+++ b/hmmlearn/tests/__init__.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sklearn.datasets.samples_generator import make_spd_matrix
+from sklearn.utils import check_random_state
 
 from hmmlearn.utils import normalize
 
@@ -7,20 +8,24 @@ from hmmlearn.utils import normalize
 np.seterr(all="warn")
 
 
-def make_covar_matrix(covariance_type, n_components, n_features):
+def make_covar_matrix(covariance_type, n_components, n_features,
+                      random_state=None):
     mincv = 0.1
-    rand = np.random.random
+    prng = check_random_state(random_state)
     if covariance_type == 'spherical':
-        return (mincv + mincv * rand((n_components,))) ** 2
+        return (mincv + mincv * prng.random_sample((n_components,))) ** 2
     elif covariance_type == 'tied':
         return (make_spd_matrix(n_features)
                 + mincv * np.eye(n_features))
     elif covariance_type == 'diag':
-        return (mincv + mincv * rand((n_components, n_features))) ** 2
+        return (mincv + mincv *
+                prng.random_sample((n_components, n_features))) ** 2
     elif covariance_type == 'full':
-        return np.array([(make_spd_matrix(n_features)
-                        + mincv * np.eye(n_features))
-                        for x in range(n_components)])
+        return np.array([
+            (make_spd_matrix(n_features, random_state=prng)
+             + mincv * np.eye(n_features))
+            for x in range(n_components)
+        ])
 
 
 def normalized(X, axis=None):

--- a/hmmlearn/tests/test_gaussian_hmm.py
+++ b/hmmlearn/tests/test_gaussian_hmm.py
@@ -24,7 +24,7 @@ class GaussianHMMTestMixin(object):
                                  (1, n_components))
         self.means = prng.randint(-20, 20, (n_components, n_features))
         self.covars = make_covar_matrix(
-            self.covariance_type, n_components, n_features
+            self.covariance_type, n_components, n_features, random_state=prng
         )
 
     def test_bad_covariance_type(self):
@@ -123,7 +123,6 @@ class GaussianHMMTestMixin(object):
         h = hmm.GaussianHMM(3, self.covariance_type)
         h.fit(X)
 
-    @pytest.mark.xfail
     def test_fit_with_priors(self, params='stmc', n_iter=5):
         startprob_prior = 10 * self.startprob + 2.0
         transmat_prior = 10 * self.transmat + 2.0

--- a/hmmlearn/tests/test_gaussian_hmm.py
+++ b/hmmlearn/tests/test_gaussian_hmm.py
@@ -123,6 +123,7 @@ class GaussianHMMTestMixin(object):
         h = hmm.GaussianHMM(3, self.covariance_type)
         h.fit(X)
 
+    @pytest.mark.xfail
     def test_fit_with_priors(self, params='stmc', n_iter=5):
         startprob_prior = 10 * self.startprob + 2.0
         transmat_prior = 10 * self.transmat + 2.0


### PR DESCRIPTION
I was investigating a local test failure on the Windows platform and wanted to see if the failure was expected or not, so I went to a recent CI build and noticed that the test suite is not actually being run on Appveyor. This PR modifies the call to `pytest` to make the tests discoverable, though perhaps supplying the path to the installed package might be preferable; I'm not much of a `pytest` expert.