### PR TITLE
Bugfix : negative self-covariances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ dist/
 htmlcov/
 oprofile_data/
 .coverage
+.coverage.*
 .gdb_history

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,14 @@ hmmlearn Changelog
 
 Here you can see the full list of changes between each hmmlearn release.
 
-next
-----
+Version 0.2.2
+-------------
+
+Released on May 5th, 2019.
+
+This version was cut in particular in order to clear up the confusion between
+the "real" v0.2.1 and the pseudo-0.2.1 that were previously released by various
+third-party packagers.
 
 - Custom ConvergenceMonitors subclasses can be used (#218).
 - MultinomialHMM now accepts unsigned symbols (#258).

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -266,6 +266,7 @@ class GaussianHMM(_BaseHMM):
                           - 2 * self.means_ * stats['obs']
                           + self.means_**2 * denom)
                 cv_den = max(covars_weight - 1, 0) + denom
+                cv_num = np.maximum(cv_num, 1e6)  # prevent negative covariances (numerical issue ?)
                 self._covars_ = \
                     (covars_prior + cv_num) / np.maximum(cv_den, 1e-5)
                 if self.covariance_type == 'spherical':

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     description="",
     long_description=open("README.rst", encoding="utf-8").read(),
     maintainer="Antony Lee",
-    maintainer_email="",
     url="https://github.com/hmmlearn/hmmlearn",
     license="new BSD",
     classifiers=[


### PR DESCRIPTION
Happens to me occasionally that self-covariances get negative values during training, resulting in nan objective. This ad-hoc patch seems to fix the (numerical ?) issue.