### PR TITLE
Include the whole convergence history in ConvergenceMonitor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ next
 ----
 
 - Fixed typo in implementation of covariance maximization for GMMHMM.
+- Changed history of ConvergenceMonitor to include the whole history for evaluation purposes. It can no longer be assumed that it has a maximum length of two.
 
 Version 0.2.4
 -------------

--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -72,7 +72,7 @@ class ConvergenceMonitor:
         self.tol = tol
         self.n_iter = n_iter
         self.verbose = verbose
-        self.history = deque(maxlen=2)
+        self.history = deque()
         self.iter = 0
 
     def __repr__(self):
@@ -115,8 +115,8 @@ class ConvergenceMonitor:
         """``True`` if the EM algorithm converged and ``False`` otherwise."""
         # XXX we might want to check that ``logprob`` is non-decreasing.
         return (self.iter == self.n_iter or
-                (len(self.history) == 2 and
-                 self.history[1] - self.history[0] < self.tol))
+                (len(self.history) >= 2 and
+                 self.history[-1] - self.history[-2] < self.tol))
 
 
 class _BaseHMM(BaseEstimator):

--- a/lib/hmmlearn/tests/test_base.py
+++ b/lib/hmmlearn/tests/test_base.py
@@ -48,6 +48,7 @@ class TestMonitor:
         out, err = capsys.readouterr()
         assert not out
         assert len(err.splitlines()) == n_iter
+        assert len(m.history) == n_iter
 
 
 class StubHMM(_BaseHMM):


### PR DESCRIPTION
As proposed in #402 

I was not sure how to declare the API change, could you give me some more information on that?