### PR TITLE
Make log_likelihood_increasing more user-friendly for tests.

### DIFF
--- a/lib/hmmlearn/tests/__init__.py
+++ b/lib/hmmlearn/tests/__init__.py
@@ -34,7 +34,7 @@ def normalized(X, axis=None):
     return X_copy
 
 
-def log_likelihood_increasing(h, X, lengths, n_iter):
+def assert_log_likelihood_increasing(h, X, lengths, n_iter):
     h.n_iter = 1        # make sure we do a single iteration at a time
     h.init_params = ''  # and don't re-init params
     log_likelihoods = np.empty(n_iter, dtype=float)
@@ -44,5 +44,10 @@ def log_likelihood_increasing(h, X, lengths, n_iter):
 
     # XXX the rounding is necessary because LL can oscillate in the
     #     fractional part, failing the tests.
-    diff = np.round(np.diff(log_likelihoods), 10) >= 0
-    return diff.all()
+    diff = np.diff(log_likelihoods)
+    rounded_diff = np.round(diff, 10)
+    diff_greater_than_zero = rounded_diff >= 0
+    assert diff_greater_than_zero.all(),  f"Non-increasing log-likelihoods:\n" \
+                                          f"diff={diff}\n" \
+                                          f"rounded_diff={rounded_diff}\n" \
+                                          f"diff>0={diff_greater_than_zero}"

--- a/lib/hmmlearn/tests/test_gaussian_hmm.py
+++ b/lib/hmmlearn/tests/test_gaussian_hmm.py
@@ -3,7 +3,7 @@ import pytest
 
 from hmmlearn import hmm
 
-from . import log_likelihood_increasing, make_covar_matrix, normalized
+from . import assert_log_likelihood_increasing, make_covar_matrix, normalized
 
 
 class GaussianHMMTestMixin:
@@ -82,7 +82,7 @@ class GaussianHMMTestMixin:
         # Mess up the parameters and see if we can re-learn them.
         # TODO: change the params and uncomment the check
         h.fit(X, lengths=lengths)
-        # assert log_likelihood_increasing(h, X, lengths, n_iter)
+        # assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
     def test_fit_ignored_init_warns(self, caplog):
         h = hmm.GaussianHMM(self.n_components, self.covariance_type)
@@ -171,7 +171,7 @@ class GaussianHMMTestMixin:
         h_learn.n_iter = 0
         h_learn.fit(X, lengths=lengths)
 
-        assert log_likelihood_increasing(h_learn, X, lengths, n_iter)
+        assert_log_likelihood_increasing(h_learn, X, lengths, n_iter)
 
         # Make sure we've converged to the right parameters.
         # a) means

--- a/lib/hmmlearn/tests/test_gmm_hmm.py
+++ b/lib/hmmlearn/tests/test_gmm_hmm.py
@@ -5,7 +5,7 @@ from sklearn.utils import check_random_state
 
 from hmmlearn import hmm
 
-from . import log_likelihood_increasing, make_covar_matrix, normalized
+from . import assert_log_likelihood_increasing, make_covar_matrix, normalized
 
 pytestmark = pytest.mark.xfail()
 
@@ -88,7 +88,7 @@ class GMMHMMTestMixin:
                                                 self.n_components), axis=1)
         h.startprob_ = normalized(self.prng.rand(self.n_components))
 
-        assert log_likelihood_increasing(h, X, lengths, n_iter)
+        assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
     def test_fit_works_on_sequences_of_different_length(self):
         lengths = [3, 4, 5]

--- a/lib/hmmlearn/tests/test_gmm_hmm_new.py
+++ b/lib/hmmlearn/tests/test_gmm_hmm_new.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from . import log_likelihood_increasing
+from . import assert_log_likelihood_increasing
 from . import normalized
 from ..hmm import GMMHMM
 
@@ -132,7 +132,7 @@ class GMMHMMTestMixin:
         self.h.startprob_ = priors0
         self.h.transmat_ = trans0
         self.h.weights_ = weights0
-        assert log_likelihood_increasing(self.h, X, lengths, n_iter)
+        assert_log_likelihood_increasing(self.h, X, lengths, n_iter)
 
     def test_fit_sparse_data(self):
         n_samples = 1000

--- a/lib/hmmlearn/tests/test_multinomial_hmm.py
+++ b/lib/hmmlearn/tests/test_multinomial_hmm.py
@@ -3,7 +3,7 @@ import pytest
 
 from hmmlearn import hmm
 
-from . import log_likelihood_increasing, normalized
+from . import assert_log_likelihood_increasing, normalized
 
 
 class TestMultinomialAgainstWikipedia:
@@ -100,7 +100,7 @@ class TestMultinomailHMM:
             np.random.random((self.n_components, self.n_features)),
             axis=1)
 
-        assert log_likelihood_increasing(h, X, lengths, n_iter)
+        assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
     def test_fit_emissionprob(self):
         self.test_fit('e')
@@ -114,7 +114,7 @@ class TestMultinomailHMM:
                                init_params=params)
         h._init(X, lengths=lengths)
 
-        assert log_likelihood_increasing(h, X, lengths, n_iter)
+        assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
     def test__check_and_set_multinomial_n_features(self):
         self.h._check_and_set_multinomial_n_features(


### PR DESCRIPTION
Transform `log_likelihood_increasing` into `assert_log_likelihood_increasing`, and provide more diagnostic information for debugging when it fails