### PR TITLE
reduce memory consumption during GHMMHMM multi sequence fits

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -206,6 +206,7 @@ for the ``GMMHMM`` model only):
 >>> X = np.random.randn(10_000, 1)  # a large input array
 >>> model = hmm.GMMHMM(n_components=3)
 >>> model.fit(X, lengths=[1000] * 10)  # split the array in 10 chunks
+GMMHMM(...
 
 Saving and loading HMM
 ----------------------

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -199,15 +199,6 @@ Finally, just call the desired method with ``X`` and ``lengths``:
 >>> hmm.GaussianHMM(n_components=3).fit(X, lengths)
 GaussianHMM(...
 
-Another reason to use ``lengths`` is when the memory becomes the bottleneck. In
-such cases, split a large input array into chunks (Note: currently available
-for the ``GMMHMM`` model only):
-
->>> X = np.random.randn(10_000, 1)  # a large input array
->>> model = hmm.GMMHMM(n_components=3)
->>> model.fit(X, lengths=[1000] * 10)  # split the array in 10 chunks
-GMMHMM(...
-
 Saving and loading HMM
 ----------------------
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -199,6 +199,13 @@ Finally, just call the desired method with ``X`` and ``lengths``:
 >>> hmm.GaussianHMM(n_components=3).fit(X, lengths)
 GaussianHMM(...
 
+Another reason to use ``lengths`` is when the memory becomes the bottleneck. In
+such cases, split a large input array into chunks (Note: currently available
+for the ``GMMHMM`` model only):
+
+>>> X = np.random.randn(10_000, 1)  # a large input array
+>>> hmm.GMMHMM(X, lengths=[1000] * 10)  # split the array in 10 chunks
+
 Saving and loading HMM
 ----------------------
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -204,7 +204,8 @@ such cases, split a large input array into chunks (Note: currently available
 for the ``GMMHMM`` model only):
 
 >>> X = np.random.randn(10_000, 1)  # a large input array
->>> hmm.GMMHMM(X, lengths=[1000] * 10)  # split the array in 10 chunks
+>>> model = hmm.GMMHMM(n_components=3)
+>>> model.fit(X, lengths=[1000] * 10)  # split the array in 10 chunks
 
 Saving and loading HMM
 ----------------------

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -945,7 +945,6 @@ class GMMHMM(_BaseHMM):
 
         n_samples, _ = X.shape
 
-        # it's totally fine to save pointers
         stats['samples'].append(X)
 
         post_mix = np.zeros((n_samples, self.n_components, self.n_mix))
@@ -993,7 +992,12 @@ class GMMHMM(_BaseHMM):
             m_d[(self.weights_ == 0) & (m_n == 0).all(axis=-1)] = 1
             self.means_ = m_n / m_d[:, :, None]
 
-        # Maximizing covariances
+        # Maximizing covariances.
+        # Iterate over 'post_comp_mix' and 'samples' in memory-efficient way
+        # and accumulate the statistics. In other words, the sequence of
+        # matrices (chunks) are not flattened in one large matrix.
+        # Though for a large number of small chunks, it'd make sense to
+        # flatten all small chunks in one array.
         if 'c' in self.params:
             lambdas, mus = self.means_weight, self.means_prior
             centered_means = self.means_ - mus

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -890,7 +890,6 @@ class GMMHMM(_BaseHMM):
 
     def _initialize_sufficient_statistics(self):
         stats = super()._initialize_sufficient_statistics()
-        stats['n_samples'] = 0
         stats['post_mix_sum'] = np.zeros((self.n_components, self.n_mix))
         stats['post_sum'] = np.zeros(self.n_components)
 
@@ -922,7 +921,6 @@ class GMMHMM(_BaseHMM):
         # make memory consumption independent of the number of samples.
         stats['post_comp_mix'] = []
         stats['samples'] = []
-        stats['centered'] = []
         return stats
 
     def _accumulate_sufficient_statistics(self, stats, X, lattice,
@@ -933,7 +931,7 @@ class GMMHMM(_BaseHMM):
 
         n_samples, _ = X.shape
 
-        stats['n_samples'] += n_samples
+        # it's totally fine to save pointers
         stats['samples'].append(X)
 
         post_mix = np.zeros((n_samples, self.n_components, self.n_mix))
@@ -950,26 +948,10 @@ class GMMHMM(_BaseHMM):
         stats['post_mix_sum'] += post_comp_mix.sum(axis=0)
         stats['post_sum'] += post_comp.sum(axis=0)
 
-        stats['centered'].append(X[:, None, None, :] - self.means_)
-
     def _do_mstep(self, stats):
         super()._do_mstep(stats)
-        ns = stats['n_samples']
-        nc = self.n_components
         nf = self.n_features
         nm = self.n_mix
-
-        # Aggregate post_comp_mix data from multiple sequences
-        post_comp_mix = np.vstack(stats['post_comp_mix'])
-        assert post_comp_mix.shape == (ns, nc, nm)
-
-        # Aggregate samples data from multiple sequences
-        samples = np.vstack(stats['samples'])
-        assert samples.shape == (ns, nf)
-
-        # Aggregate centered data from multiple sequences
-        centered = np.vstack(stats['centered'])
-        assert centered.shape == (ns, nc, nm, nf)
 
         # Maximizing weights
         if 'w' in self.params:
@@ -978,14 +960,16 @@ class GMMHMM(_BaseHMM):
             w_d = (stats['post_sum'] + alphas_minus_one.sum(axis=1))[:, None]
             self.weights_ = w_n / w_d
 
+        means_before_update = self.means_.copy()
+
         # Maximizing means
         if 'm' in self.params:
             lambdas, mus = self.means_weight, self.means_prior
-            m_n = (
-                np.einsum('ijk,il->jkl',
-                          post_comp_mix, samples)
-                + lambdas[:, :, None] * mus
-            )
+            m_n = lambdas[:, :, None] * mus
+            for post_comp_mix, samples in zip(stats['post_comp_mix'],
+                                              stats['samples']):
+                m_n += np.einsum('ijk,il->jkl', post_comp_mix, samples)
+
             m_d = stats['post_mix_sum'] + lambdas
             # If a componenent has zero weight, then replace nan (0/0?) means
             # by 0 (0/1).  The actual value is irrelevant as the component will
@@ -997,69 +981,76 @@ class GMMHMM(_BaseHMM):
 
         # Maximizing covariances
         if 'c' in self.params:
+            lambdas, mus = self.means_weight, self.means_prior
             centered_means = self.means_ - mus
 
             def outer_f(x):  # Outer product over features.
                 return x[..., :, None] * x[..., None, :]
 
             if self.covariance_type == 'full':
-                centered_dots = outer_f(centered)
                 centered_means_dots = outer_f(centered_means)
 
                 psis_t = np.transpose(self.covars_prior, axes=(0, 1, 3, 2))
                 nus = self.covars_weight
 
-                c_n = (
-                    np.einsum('ijk,ijklm->jklm', post_comp_mix, centered_dots)
-                    + psis_t
-                    + lambdas[:, :, None, None] * centered_means_dots
-                )
+                c_n = psis_t + lambdas[:, :, None, None] * centered_means_dots
+                for post_comp_mix, samples in zip(stats['post_comp_mix'],
+                                                  stats['samples']):
+                    centered = samples[:, None, None, :] - means_before_update
+                    centered_dots = outer_f(centered)
+                    c_n += np.einsum('ijk,ijklm->jklm', post_comp_mix,
+                                     centered_dots)
                 c_d = (
                     stats['post_mix_sum'] + 1 + nus + nf + 1
                 )[:, :, None, None]
 
             elif self.covariance_type == 'diag':
-                centered2 = centered ** 2
-                centered_means2 = centered_means ** 2
-
                 alphas = self.covars_prior
                 betas = self.covars_weight
+                centered_means2 = centered_means ** 2
 
-                c_n = (
-                    np.einsum('ijk,ijkl->jkl', post_comp_mix, centered2)
-                    + lambdas[:, :, None] * centered_means2
-                    + 2 * betas
-                )
+                c_n = lambdas[:, :, None] * centered_means2 + 2 * betas
+                for post_comp_mix, samples in zip(stats['post_comp_mix'],
+                                                  stats['samples']):
+                    centered = samples[:, None, None, :] - means_before_update
+                    centered2 = np.square(centered, out=centered)  # reuse
+                    c_n += np.einsum('ijk,ijkl->jkl', post_comp_mix, centered2)
+
                 c_d = stats['post_mix_sum'][:, :, None] + 1 + 2 * (alphas + 1)
 
             elif self.covariance_type == 'spherical':
                 # Much faster than (x**2).sum(-1).
                 def norm_last(x): return np.einsum('...i,...i', x, x)
-                centered_norm2 = norm_last(centered)
                 centered_means_norm2 = norm_last(centered_means)
 
                 alphas = self.covars_prior
                 betas = self.covars_weight
 
-                c_n = (
-                    np.einsum('ijk,ijk->jk', post_comp_mix, centered_norm2)
-                    + lambdas * centered_means_norm2
-                    + 2 * betas
-                )
+                c_n = lambdas * centered_means_norm2 + 2 * betas
+                for post_comp_mix, samples in zip(stats['post_comp_mix'],
+                                                  stats['samples']):
+                    centered = samples[:, None, None, :] - means_before_update
+                    centered_norm = norm_last(centered)
+                    c_n += np.einsum('ijk,ijk->jk', post_comp_mix,
+                                     centered_norm)
+
                 c_d = nf * (stats['post_mix_sum'] + 1) + 2 * (alphas + 1)
 
             elif self.covariance_type == 'tied':
-                centered_dots = outer_f(centered)
                 centered_means_dots = outer_f(centered_means)
 
                 psis_t = np.transpose(self.covars_prior, axes=(0, 2, 1))
                 nus = self.covars_weight
 
-                c_n = (
-                    np.einsum('ijk,ijklm->jlm', post_comp_mix, centered_dots)
-                    + np.einsum('ij,ijkl->ikl', lambdas, centered_means_dots)
-                    + psis_t
-                )
+                c_n = np.einsum('ij,ijkl->ikl', lambdas, centered_means_dots) \
+                      + psis_t
+                for post_comp_mix, samples in zip(stats['post_comp_mix'],
+                                                  stats['samples']):
+                    centered = samples[:, None, None, :] - means_before_update
+                    centered_dots = outer_f(centered)
+                    c_n += np.einsum('ijk,ijklm->jlm', post_comp_mix,
+                                     centered_dots)
+
                 c_d = (stats['post_sum'] + nm + nus + nf + 1)[:, None, None]
 
             self.covars_ = c_n / c_d

--- a/lib/hmmlearn/tests/test_gmm_hmm_new.py
+++ b/lib/hmmlearn/tests/test_gmm_hmm_new.py
@@ -201,31 +201,30 @@ class TestGMMHMMWithFullCovars(GMMHMMTestMixin):
 
 
 class TestGMMHMM_MultiSequence:
-    def test_chunked(self):
-        np.random.seed(0)
 
-        gmm = create_random_gmm(3, 2, covariance_type="diag")
+    @pytest.mark.parametrize("covtype",
+                             ["diag", "spherical", "tied", "full"])
+    def test_chunked(sellf, covtype):
+        np.random.seed(0)
+        gmm = create_random_gmm(3, 2, covariance_type=covtype, prng=0)
         gmm.covariances_ = gmm.covars_
         data = gmm.sample(n_samples=1000)[0]
 
-        for covtype in COVARIANCE_TYPES:
-            model1 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype)
-            model2 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype)
+        model1 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype,
+                        random_state=1)
+        model2 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype,
+                        random_state=1)
+        model1.fit(data)
+        model2.fit(data, lengths=[200] * 5)
 
-            np.random.seed(1)
-            model1.fit(data)
-
-            np.random.seed(1)
-            model2.fit(data, lengths=[100] * 10)
-
-            assert_array_almost_equal(model1.means_, model2.means_,
-                                      decimal=2)
-            assert_array_almost_equal(model1.covars_, model2.covars_,
-                                      decimal=3)
-            assert_array_almost_equal(model1.weights_, model2.weights_,
-                                      decimal=3)
-            assert_array_almost_equal(model1.transmat_, model2.transmat_,
-                                      decimal=2)
+        assert_array_almost_equal(model1.means_, model2.means_,
+                                  decimal=2)
+        assert_array_almost_equal(model1.covars_, model2.covars_,
+                                  decimal=3)
+        assert_array_almost_equal(model1.weights_, model2.weights_,
+                                  decimal=3)
+        assert_array_almost_equal(model1.transmat_, model2.transmat_,
+                                  decimal=2)
 
 
 class TestGMMHMM_KmeansInit:

--- a/lib/hmmlearn/tests/test_gmm_hmm_new.py
+++ b/lib/hmmlearn/tests/test_gmm_hmm_new.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 from . import assert_log_likelihood_increasing
 from . import normalized
-from ..hmm import GMMHMM
+from .test_gmm_hmm import create_random_gmm
+from ..hmm import GMMHMM, COVARIANCE_TYPES
 
 
 def sample_from_parallelepiped(low, high, n_samples, random_state):
@@ -194,3 +196,31 @@ class TestGMMHMMWithTiedCovars(GMMHMMTestMixin):
 
 class TestGMMHMMWithFullCovars(GMMHMMTestMixin):
     covariance_type = 'full'
+
+
+class TestGMMHMM_MultiSequence:
+    def test_chunked(self):
+        np.random.seed(0)
+
+        gmm = create_random_gmm(3, 2, covariance_type="diag")
+        gmm.covariances_ = gmm.covars_
+        data = gmm.sample(n_samples=1000)[0]
+
+        for covtype in COVARIANCE_TYPES:
+            model1 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype)
+            model2 = GMMHMM(n_components=3, n_mix=2, covariance_type=covtype)
+
+            np.random.seed(1)
+            model1.fit(data)
+
+            np.random.seed(1)
+            model2.fit(data, lengths=[100] * 10)
+
+            assert_array_almost_equal(model1.means_, model2.means_,
+                                      decimal=2)
+            assert_array_almost_equal(model1.covars_, model2.covars_,
+                                      decimal=3)
+            assert_array_almost_equal(model1.weights_, model2.weights_,
+                                      decimal=3)
+            assert_array_almost_equal(model1.transmat_, model2.transmat_,
+                                      decimal=2)


### PR DESCRIPTION
Hi, today I learned about your package, started to use it, faced the memory problem, and came up with a PR that fixes it.

I've exploited the `lengths` option and added another meaning to it. Currently, for the `GMMHMM` only. Curious users will find a way to extend my implementation to other models as well.

This also partially addresses the comment left in https://github.com/hmmlearn/hmmlearn/commit/08dee6640483cda232f7d2fcc7935d4008f4d368:

https://github.com/hmmlearn/hmmlearn/blob/0562ca65756ffb60da836eeeb1845e61767c705b/lib/hmmlearn/hmm.py#L918-L922


I got rid of the unnecessary `'centered'` arrays in the `stats` dict. If you don't want to store the `post_comp_mix` matrices in the `stats`, the logic of computing intermediate variables - `c_n` and `c_d` for the covariance - should be moved from the `_do_mstep` to `_accumulate_sufficient_statistics` function. Since this is my first PR, I've decided not to rummage through your code a lot. In either case, this should be considered in a separate PR, if you will.

Best,
Danylo