### PR TITLE
add score_batches method which returns a list of scores

### DIFF
--- a/lib/hmmlearn/_hmmc.pyx
+++ b/lib/hmmlearn/_hmmc.pyx
@@ -23,6 +23,8 @@ cdef inline dtype_t _max(dtype_t[:] X) nogil:
 
 cdef inline dtype_t _logsumexp(dtype_t[:] X) nogil:
     cdef dtype_t X_max = _max(X)
+    cdef ssize_t i
+
     if isinf(X_max):
         return -INFINITY
 

--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -253,6 +253,64 @@ class _BaseHMM(BaseEstimator):
         """
         return self._score(X, lengths, compute_posteriors=False)[0]
 
+    def score_batches(self, X, lengths=None):
+        """
+        Compute the log probability under the model.
+        Compared to score() it returns a list of probabilities and doesn't add them up.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Feature matrix of individual samples.
+        lengths : array-like of integers, shape (n_sequences, ), optional
+            Lengths of the individual sequences in ``X``. The sum of
+            these should be ``n_samples``.
+
+        Returns
+        -------
+        logprobs : List[float]
+            Log likelihoods of sequences in ``X``.
+
+        """
+
+        _utils.check_is_fitted(self, "startprob_")
+        self._check()
+
+        X = check_array(X)
+        impl = {
+            "scaling": self._score_batches_scaling,
+            "log": self._score_batches_log,
+        }[self.implementation]
+        return impl(X=X, lengths=lengths)
+
+    def _score_batches_log(self, X, lengths=None):
+
+        logprobs = []
+        for sub_X in _utils.split_X_lengths(X, lengths):
+            try:
+                framelogprob = self._compute_log_likelihood(sub_X)
+            except IndexError:
+                logprobij = -np.inf
+            else:
+                logprobij, _ = self._do_forward_log_pass(framelogprob)
+            logprobs.append(logprobij)
+
+        return logprobs
+
+    def _score_batches_scaling(self, X, lengths=None):
+
+        logprobs = []
+        for sub_X in _utils.split_X_lengths(X, lengths):
+            try:
+                frameprob = self._compute_likelihood(sub_X)
+            except IndexError:
+                logprobij = -np.inf
+            else:
+                logprobij, _, _ = self._do_forward_scaling_pass(frameprob)
+            logprobs.append(logprobij)
+
+        return logprobs
+
     def _score(self, X, lengths=None, *, compute_posteriors):
         """
         Helper for `score` and `score_samples`.

--- a/lib/hmmlearn/tests/test_base.py
+++ b/lib/hmmlearn/tests/test_base.py
@@ -149,6 +149,22 @@ class TestBaseAgainstWikipedia:
                                   [0.8673, 0.1327]])
         assert np.allclose(posteriors, refposteriors, atol=1e-4)
 
+    def test_score_batches_log(self):
+        # ``StubHMM` ignores the values in ```X``, so we just pass in an
+        # array of the appropriate shape.
+        logprobs = self.hmm._score_batches_log(self.framelogprob)
+
+        reflogprob = -3.3725
+        assert round(sum(logprobs), 4) == reflogprob
+
+    def test_score_batches_scaling(self):
+        # ``StubHMM` ignores the values in ```X``, so we just pass in an
+        # array of the appropriate shape.
+        logprobs = self.hmm._score_batches_scaling(self.frameprob)
+
+        reflogprob = -3.3725
+        assert round(sum(logprobs), 4) == reflogprob
+
     def test_generate_samples(self):
         X0, Z0 = self.hmm.sample(n_samples=10)
         X, Z = self.hmm.sample(n_samples=10, currstate=Z0[-1])


### PR DESCRIPTION
Added `score_batches` method which returns a list of scores (one for each sequence) instead of a cumulative score.

See https://github.com/hmmlearn/hmmlearn/issues/272