### PR TITLE
_init() function does not require lengths

### DIFF
--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -485,7 +485,7 @@ class _BaseHMM(BaseEstimator):
             Returns self.
         """
         X = check_array(X)
-        self._init(X, lengths=lengths)
+        self._init(X)
         self._check()
 
         self.monitor_._reset()
@@ -606,7 +606,7 @@ class _BaseHMM(BaseEstimator):
         for a non-degenerate fit.
         """
 
-    def _init(self, X, lengths):
+    def _init(self, X):
         """
         Initialize model parameters prior to fitting.
 
@@ -614,9 +614,6 @@ class _BaseHMM(BaseEstimator):
         ----------
         X : array-like, shape (n_samples, n_features)
             Feature matrix of individual samples.
-        lengths : array-like of integers, shape (n_sequences, )
-            Lengths of the individual sequences in ``X``. The sum of
-            these should be ``n_samples``.
         """
         init = 1. / self.n_components
         if self._needs_init("s", "startprob_"):

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -192,9 +192,9 @@ class GaussianHMM(_BaseHMM):
             }[self.covariance_type],
         }
 
-    def _init(self, X, lengths=None):
+    def _init(self, X):
         _check_and_set_gaussian_n_features(self, X)
-        super()._init(X, lengths=lengths)
+        super()._init(X)
 
         if self._needs_init("m", "means_"):
             kmeans = cluster.KMeans(n_clusters=self.n_components,
@@ -438,9 +438,9 @@ class MultinomialHMM(_BaseHMM):
             "e": nc * (nf - 1),
         }
 
-    def _init(self, X, lengths=None):
+    def _init(self, X):
         self._check_and_set_multinomial_n_features(X)
-        super()._init(X, lengths=lengths)
+        super()._init(X)
         self.random_state = check_random_state(self.random_state)
 
         if 'e' in self.init_params:
@@ -660,9 +660,9 @@ class GMMHMM(_BaseHMM):
             "w": nm - 1,
         }
 
-    def _init(self, X, lengths=None):
+    def _init(self, X):
         _check_and_set_gaussian_n_features(self, X)
-        super()._init(X, lengths=lengths)
+        super()._init(X)
         nc = self.n_components
         nf = self.n_features
         nm = self.n_mix

--- a/lib/hmmlearn/tests/test_multinomial_hmm.py
+++ b/lib/hmmlearn/tests/test_multinomial_hmm.py
@@ -133,7 +133,7 @@ class TestMultinomailHMM:
         # use init_function to initialize paramerters
         h = hmm.MultinomialHMM(self.n_components, params=params,
                                init_params=params)
-        h._init(X, lengths=lengths)
+        h._init(X)
 
         assert_log_likelihood_increasing(h, X, lengths, n_iter)
 


### PR DESCRIPTION
The `lengths` is not used in the `_init()` function.