### PR TITLE
Make BaseHMM public.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ next
 
 - Dropped support for Py3.5 (due to the absence of manylinux wheel supporting
   both Py3.5 and Py3.10).
+- ``_BaseHMM`` has been promoted to public API and has been renamed to
+  ``BaseHMM``.
 - MultinomialHMM no longer overwrites preset ``n_features``.
 - An implementation of the Forward-Backward algorithm based upon scaling
   is available by specifying ``implementation="scaling"`` when instantiating

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -16,10 +16,10 @@ ConvergenceMonitor
 
 .. autoclass:: hmmlearn.base.ConvergenceMonitor
 
-_BaseHMM
+BaseHMM
 ~~~~~~~~
 
-.. autoclass:: hmmlearn.base._BaseHMM
+.. autoclass:: hmmlearn.base.BaseHMM
    :exclude-members: set_params, get_params, _get_param_names
    :private-members:
    :no-inherited-members:

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -61,7 +61,7 @@ Building HMM and generating samples
 
 You can build a HMM instance by passing the parameters described above to the
 constructor. Then, you can generate samples from the HMM by calling
-:meth:`~base._BaseHMM.sample`.
+:meth:`~.BaseHMM.sample`.
 
 >>> import numpy as np
 >>> from hmmlearn import hmm
@@ -86,7 +86,7 @@ left-right HMM can be defined as follows:
 ...                          [0.0, 0.5, 0.5],
 ...                          [0.0, 0.0, 1.0]])
 
-If any of the required parameters are missing, :meth:`~base._BaseHMM.sample`
+If any of the required parameters are missing, :meth:`~.BaseHMM.sample`
 will raise an exception:
 
 >>> model = hmm.GaussianHMM(n_components=3)
@@ -105,7 +105,7 @@ either random or computed from the data. It is possible to hook into this
 process and provide a starting point explicitly. To do so
 
 1. ensure that the character code for the parameter is missing from
-   :attr:`~base._BaseHMM.init_params` and then
+   :attr:`~.BaseHMM.init_params` and then
 2. set the parameter to the desired value.
 
 For example, consider a HMM with an explicitly initialized transition
@@ -118,7 +118,7 @@ probability matrix:
 
 A similar trick applies to parameter estimation. If you want to fix some
 parameter at a specific value, remove the corresponding character from
-:attr:`~base._BaseHMM.params` and set the parameter value before training.
+:attr:`~.BaseHMM.params` and set the parameter value before training.
 
 .. topic:: Examples:
 
@@ -127,7 +127,7 @@ parameter at a specific value, remove the corresponding character from
 Training HMM parameters and inferring the hidden states
 -------------------------------------------------------
 
-You can train an HMM by calling the :meth:`~base._BaseHMM.fit` method. The input
+You can train an HMM by calling the :meth:`~.BaseHMM.fit` method. The input
 is a matrix of concatenated sequences of observations (*aka* samples) along with
 the lengths of the sequences (see :ref:`Working with multiple sequences <multiple_sequences>`).
 
@@ -135,10 +135,10 @@ Note, since the EM algorithm is a gradient-based optimization method, it will
 generally get stuck in local optima. You should in general try to run ``fit``
 with various initializations and select the highest scored model.
 
-The score of the model can be calculated by the :meth:`~base._BaseHMM.score` method.
+The score of the model can be calculated by the :meth:`~.BaseHMM.score` method.
 
 The inferred optimal hidden states can be obtained by calling
-:meth:`~base._BaseHMM.predict` method. The ``predict`` method can be
+:meth:`~.BaseHMM.predict` method. The ``predict`` method can be
 specified with a decoder algorithm. Currently the Viterbi algorithm
 (``"viterbi"``), and maximum a posteriori estimation (``"map"``) are supported.
 
@@ -159,8 +159,7 @@ change in score is lower than the specified threshold ``tol``. Note, that
 depending on the data, the EM algorithm may or may not achieve convergence in the
 given number of steps.
 
-You can use the :attr:`~base._BaseHMM.monitor_` attribute to diagnose
-convergence:
+You can use the :attr:`~.BaseHMM.monitor_` attribute to diagnose convergence:
 
 >>> remodel.monitor_
 ConvergenceMonitor(
@@ -187,8 +186,8 @@ Consider two 1D sequences:
 >>> X1 = [[0.5], [1.0], [-1.0], [0.42], [0.24]]
 >>> X2 = [[2.4], [4.2], [0.5], [-0.24]]
 
-To pass both sequences to :meth:`~base._BaseHMM.fit` or
-:meth:`~base._BaseHMM.predict`, first concatenate them into a single array and
+To pass both sequences to :meth:`~.BaseHMM.fit` or
+:meth:`~.BaseHMM.predict`, first concatenate them into a single array and
 then compute an array of sequence lengths:
 
 >>> X = np.concatenate([X1, X2])
@@ -216,19 +215,19 @@ Implementing HMMs with custom emission probabilities
 ----------------------------------------------------
 
 If you want to implement a custom emission probability (e.g. Poisson), you have to
-subclass :class:`~base._BaseHMM` and override the following methods
+subclass :class:`~.BaseHMM` and override the following methods
 
 .. autosummary::
 
-   base._BaseHMM._init
-   base._BaseHMM._check
-   base._BaseHMM._generate_sample_from_state
-   base._BaseHMM._compute_log_likelihood
-   base._BaseHMM._compute_likelihood
-   base._BaseHMM._initialize_sufficient_statistics
-   base._BaseHMM._accumulate_sufficient_statistics
-   base._BaseHMM._do_mstep
+   BaseHMM._init
+   BaseHMM._check
+   BaseHMM._generate_sample_from_state
+   BaseHMM._compute_log_likelihood
+   BaseHMM._compute_likelihood
+   BaseHMM._initialize_sufficient_statistics
+   BaseHMM._accumulate_sufficient_statistics
+   BaseHMM._do_mstep
 
-Optionally, only one of `base._BaseHMM._compute_likelihood` and
-`base._BaseHMM._compute_log_likelihood` need to be overridden, and the
+Optionally, only one of `~.BaseHMM._compute_likelihood` and
+`~.BaseHMM._compute_log_likelihood` need to be overridden, and the
 base implementation will provide the other.

--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -117,15 +117,12 @@ class ConvergenceMonitor:
                  self.history[-1] - self.history[-2] < self.tol))
 
 
-class _BaseHMM(BaseEstimator):
+class BaseHMM(BaseEstimator):
     """
     Base class for Hidden Markov Models.
 
-    This class allows for easy evaluation of, sampling from, and
-    maximum a posteriori estimation of the parameters of a HMM.
-
-    See the instance documentation for details specific to a
-    particular object.
+    This class allows for easy evaluation of, sampling from, and maximum a
+    posteriori estimation of the parameters of a HMM.
 
     Attributes
     ----------
@@ -135,6 +132,14 @@ class _BaseHMM(BaseEstimator):
         Initial state occupation distribution.
     transmat_ : array, shape (n_components, n_components)
         Matrix of transition probabilities between states.
+
+    Notes
+    -----
+    Normally, one should use a subclass of `.BaseHMM`, with its specialization
+    towards a given emission model.  In rare cases, the base class can also be
+    useful in itself, if one simply wants to generate a sequence of states
+    using `.BaseHMM.sample`.  In that case, the feature matrix will have zero
+    features.
     """
 
     def __init__(self, n_components=1,
@@ -678,7 +683,7 @@ class _BaseHMM(BaseEstimator):
             model states.
         """
         if self._compute_log_likelihood != \
-           _BaseHMM._compute_log_likelihood.__get__(self):  # prevent recursion
+            BaseHMM._compute_log_likelihood.__get__(self):  # prevent recursion
             return np.exp(self._compute_log_likelihood(X))
         else:
             raise NotImplementedError("Must be overridden in subclass")
@@ -699,7 +704,7 @@ class _BaseHMM(BaseEstimator):
             model states, i.e., ``log(p(X|state))``.
         """
         if self._compute_likelihood != \
-           _BaseHMM._compute_likelihood.__get__(self):  # prevent recursion
+            BaseHMM._compute_likelihood.__get__(self):  # prevent recursion
             return np.log(self._compute_likelihood(X))
         else:
             raise NotImplementedError("Must be overridden in subclass")
@@ -722,6 +727,7 @@ class _BaseHMM(BaseEstimator):
             A random sample from the emission distribution corresponding
             to a given component.
         """
+        return ()
 
     # Methods used by self.fit()
 
@@ -758,7 +764,7 @@ class _BaseHMM(BaseEstimator):
         ----------
         stats : dict
             Sufficient statistics as returned by
-            :meth:`~base._BaseHMM._initialize_sufficient_statistics`.
+            :meth:`~.BaseHMM._initialize_sufficient_statistics`.
 
         X : array, shape (n_samples, n_features)
             Sample sequence.
@@ -847,3 +853,6 @@ class _BaseHMM(BaseEstimator):
             transmat_ = np.maximum(self.transmat_prior - 1 + stats['trans'], 0)
             self.transmat_ = np.where(self.transmat_ == 0, 0, transmat_)
             normalize(self.transmat_, axis=1)
+
+
+_BaseHMM = BaseHMM  # Backcompat name, will be deprecated in the future.

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -13,7 +13,7 @@ from sklearn.utils import check_random_state
 
 from . import _utils
 from .stats import log_multivariate_normal_density
-from .base import _BaseHMM
+from .base import BaseHMM
 from .utils import fill_covars, log_mask_zero, log_normalize, normalize
 
 __all__ = ["GMMHMM", "GaussianHMM", "MultinomialHMM"]
@@ -34,7 +34,7 @@ def _check_and_set_gaussian_n_features(model, X):
         model.n_features = n_features
 
 
-class GaussianHMM(_BaseHMM):
+class GaussianHMM(BaseHMM):
     """
     Hidden Markov Model with Gaussian emissions.
 
@@ -150,13 +150,13 @@ class GaussianHMM(_BaseHMM):
             logarithms ("log"), or using scaling ("scaling").  The default is
             to use logarithms for backwards compatability.
         """
-        _BaseHMM.__init__(self, n_components,
-                          startprob_prior=startprob_prior,
-                          transmat_prior=transmat_prior, algorithm=algorithm,
-                          random_state=random_state, n_iter=n_iter,
-                          tol=tol, params=params, verbose=verbose,
-                          init_params=init_params,
-                          implementation=implementation)
+        BaseHMM.__init__(self, n_components,
+                         startprob_prior=startprob_prior,
+                         transmat_prior=transmat_prior, algorithm=algorithm,
+                         random_state=random_state, n_iter=n_iter,
+                         tol=tol, params=params, verbose=verbose,
+                         init_params=init_params,
+                         implementation=implementation)
         self.covariance_type = covariance_type
         self.min_covar = min_covar
         self.means_prior = means_prior
@@ -331,7 +331,7 @@ def _multinomialhmm_fix_docstring_shape(func):
     return wrapper
 
 
-class MultinomialHMM(_BaseHMM):
+class MultinomialHMM(BaseHMM):
     """
     Hidden Markov Model with multinomial (discrete) emissions.
 
@@ -409,24 +409,24 @@ class MultinomialHMM(_BaseHMM):
             logarithms ("log"), or using scaling ("scaling").  The default is
             to use logarithms for backwards compatability.
         """
-        _BaseHMM.__init__(self, n_components,
-                          startprob_prior=startprob_prior,
-                          transmat_prior=transmat_prior,
-                          algorithm=algorithm,
-                          random_state=random_state,
-                          n_iter=n_iter, tol=tol, verbose=verbose,
-                          params=params, init_params=init_params,
-                          implementation=implementation)
+        BaseHMM.__init__(self, n_components,
+                         startprob_prior=startprob_prior,
+                         transmat_prior=transmat_prior,
+                         algorithm=algorithm,
+                         random_state=random_state,
+                         n_iter=n_iter, tol=tol, verbose=verbose,
+                         params=params, init_params=init_params,
+                         implementation=implementation)
 
     score_samples, score, decode, predict, predict_proba, sample, fit = map(
         _multinomialhmm_fix_docstring_shape, [
-            _BaseHMM.score_samples,
-            _BaseHMM.score,
-            _BaseHMM.decode,
-            _BaseHMM.predict,
-            _BaseHMM.predict_proba,
-            _BaseHMM.sample,
-            _BaseHMM.fit,
+            BaseHMM.score_samples,
+            BaseHMM.score,
+            BaseHMM.decode,
+            BaseHMM.predict,
+            BaseHMM.predict_proba,
+            BaseHMM.sample,
+            BaseHMM.fit,
         ])
 
     def _get_n_fit_scalars_per_param(self):
@@ -506,7 +506,7 @@ class MultinomialHMM(_BaseHMM):
             self.n_features = X.max() + 1
 
 
-class GMMHMM(_BaseHMM):
+class GMMHMM(BaseHMM):
     """
     Hidden Markov Model with Gaussian mixture emissions.
 
@@ -627,13 +627,13 @@ class GMMHMM(_BaseHMM):
             logarithms ("log"), or using scaling ("scaling").  The default is
             to use logarithms for backwards compatability.
         """
-        _BaseHMM.__init__(self, n_components,
-                          startprob_prior=startprob_prior,
-                          transmat_prior=transmat_prior,
-                          algorithm=algorithm, random_state=random_state,
-                          n_iter=n_iter, tol=tol, verbose=verbose,
-                          params=params, init_params=init_params,
-                          implementation=implementation)
+        BaseHMM.__init__(self, n_components,
+                         startprob_prior=startprob_prior,
+                         transmat_prior=transmat_prior,
+                         algorithm=algorithm, random_state=random_state,
+                         n_iter=n_iter, tol=tol, verbose=verbose,
+                         params=params, init_params=init_params,
+                         implementation=implementation)
         self.covariance_type = covariance_type
         self.min_covar = min_covar
         self.n_mix = n_mix
@@ -909,7 +909,7 @@ class GMMHMM(_BaseHMM):
         # The following statistics are stored in lists so we can
         # accumulate chunks of data for multiple sequences (aka
         # multiple frames) during fitting. The fit(X, lengths) method
-        # in the _BaseHMM class will call
+        # in the BaseHMM class will call
         # _accumulate_sufficient_statistics once per sequence in the
         # training samples. Data from all sequences needs to be
         # accumulated and fed into _do_mstep.

--- a/lib/hmmlearn/tests/test_base.py
+++ b/lib/hmmlearn/tests/test_base.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from scipy import special
-from hmmlearn.base import _BaseHMM, ConvergenceMonitor
+from hmmlearn.base import BaseHMM, ConvergenceMonitor
 
 
 class TestMonitor:
@@ -50,7 +50,7 @@ class TestMonitor:
         assert len(m.history) == n_iter
 
 
-class StubHMM(_BaseHMM):
+class StubHMM(BaseHMM):
     """An HMM with hardcoded observation probabilities."""
     def _compute_log_likelihood(self, X):
         return self.log_frameprob


### PR DESCRIPTION
In rare cases, directly instantiating BaseHMM can be useful for end
users, e.g. to sample states from a Markov chain.  So make the class
public.

Thoughts?