### PR TITLE
GMMHMM: moved for-loops computations from _do_mstep to _accumulate_sufficient_statistics

### DIFF
--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -940,7 +940,6 @@ class GMMHMM(_BaseHMM):
 
         with np.errstate(under="ignore"):
             post_comp_mix = post_comp[:, :, None] * post_mix
-        stats['post_comp_mix'].append(post_comp_mix)
 
         stats['post_mix_sum'] += post_comp_mix.sum(axis=0)
         stats['post_sum'] += post_comp.sum(axis=0)
@@ -965,7 +964,6 @@ class GMMHMM(_BaseHMM):
                 centered2 = np.square(centered, out=centered)  # reuse
                 c_n = np.einsum('ijk,ijkl->jkl', post_comp_mix, centered2)
             elif self.covariance_type == 'spherical':
-
                 centered_norm = norm_last(centered)
                 c_n = np.einsum('ijk,ijk->jk', post_comp_mix, centered_norm)
             elif self.covariance_type == 'tied':

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -906,34 +906,16 @@ class GMMHMM(_BaseHMM):
         stats['post_mix_sum'] = np.zeros((self.n_components, self.n_mix))
         stats['post_sum'] = np.zeros(self.n_components)
 
-        # The following statistics are stored in lists so we can
-        # accumulate chunks of data for multiple sequences (aka
+        lambdas, mus = self.means_weight, self.means_prior
+        stats['m_n'] = lambdas[:, :, None] * mus
+
+        # These statistics are stored in arrays and updated in-place.
+        # We accumulate chunks of data for multiple sequences (aka
         # multiple frames) during fitting. The fit(X, lengths) method
         # in the _BaseHMM class will call
         # _accumulate_sufficient_statistics once per sequence in the
         # training samples. Data from all sequences needs to be
         # accumulated and fed into _do_mstep.
-        #
-        # Suppose fit(X, lengths) is called with M>=1 sequences, where
-        # each sequence s=0, ..., M-1 contains L[s] = lengths[s]
-        # ordered samples. Then after M calls to
-        # _accumulate_sufficient_statistics, one per sequence, we
-        # expect each list statistic to contain M items, all arrays,
-        # with the following shapes:
-        #
-        # stat              shape of s-th item
-        #
-        # post_comp_mix     (L[s], n_components, n_mix)
-        # samples           (L[s], n_features)
-        # centred           (L[s], n_components, n_mix, n_features)
-        #
-        # FIXME this encoding requires memory proportional to the
-        # number of samples. It would be preferable to rework the
-        # calculations in _do_mstep to reduce over the samples axis
-        # earlier during _accumulate_sufficient_statistics in order to
-        # make memory consumption independent of the number of samples.
-        stats['post_comp_mix'] = []
-        stats['samples'] = []
         return stats
 
     def _accumulate_sufficient_statistics(self, stats, X, lattice,
@@ -944,7 +926,10 @@ class GMMHMM(_BaseHMM):
 
         n_samples, _ = X.shape
 
-        stats['samples'].append(X)
+        # Statistics shapes:
+        # post_comp_mix     (n_samples, n_components, n_mix)
+        # samples           (n_samples, n_features)
+        # centred           (n_samples, n_components, n_mix, n_features)
 
         post_mix = np.zeros((n_samples, self.n_components, self.n_mix))
         for p in range(self.n_components):
@@ -960,6 +945,38 @@ class GMMHMM(_BaseHMM):
         stats['post_mix_sum'] += post_comp_mix.sum(axis=0)
         stats['post_sum'] += post_comp.sum(axis=0)
 
+        # means stats
+        stats['m_n'] += np.einsum('ijk,il->jkl', post_comp_mix, X)
+
+        if 'c' in self.params:  # covariance stats
+            centered = X[:, None, None, :] - self.means_
+
+            def outer_f(x):  # Outer product over features.
+                return x[..., :, None] * x[..., None, :]
+
+            def norm_last(x):  # Much faster than (x**2).sum(-1).
+                return np.einsum('...i,...i', x, x)
+
+            if self.covariance_type == 'full':
+                centered_dots = outer_f(centered)
+                c_n = np.einsum('ijk,ijklm->jklm', post_comp_mix,
+                                     centered_dots)
+            elif self.covariance_type == 'diag':
+                centered2 = np.square(centered, out=centered)  # reuse
+                c_n = np.einsum('ijk,ijkl->jkl', post_comp_mix, centered2)
+            elif self.covariance_type == 'spherical':
+
+                centered_norm = norm_last(centered)
+                c_n = np.einsum('ijk,ijk->jk', post_comp_mix, centered_norm)
+            elif self.covariance_type == 'tied':
+                centered_dots = outer_f(centered)
+                c_n = np.einsum('ijk,ijklm->jlm', post_comp_mix, centered_dots)
+
+            if 'c_n' in stats:
+                stats['c_n'] += c_n
+            else:
+                stats['c_n'] = c_n
+
     def _do_mstep(self, stats):
         super()._do_mstep(stats)
         nf = self.n_features
@@ -972,17 +989,10 @@ class GMMHMM(_BaseHMM):
             w_d = (stats['post_sum'] + alphas_minus_one.sum(axis=1))[:, None]
             self.weights_ = w_n / w_d
 
-        means_before_update = self.means_.copy()
-
         # Maximizing means
         if 'm' in self.params:
-            lambdas, mus = self.means_weight, self.means_prior
-            m_n = lambdas[:, :, None] * mus
-            for post_comp_mix, samples in zip(stats['post_comp_mix'],
-                                              stats['samples']):
-                m_n += np.einsum('ijk,il->jkl', post_comp_mix, samples)
-
-            m_d = stats['post_mix_sum'] + lambdas
+            m_n = stats['m_n']
+            m_d = stats['post_mix_sum'] + self.means_weight
             # If a componenent has zero weight, then replace nan (0/0?) means
             # by 0 (0/1).  The actual value is irrelevant as the component will
             # be unused.  This needs to be done before maximizing covariances
@@ -992,11 +1002,6 @@ class GMMHMM(_BaseHMM):
             self.means_ = m_n / m_d[:, :, None]
 
         # Maximizing covariances.
-        # Iterate over 'post_comp_mix' and 'samples' in memory-efficient way
-        # and accumulate the statistics. In other words, the sequence of
-        # matrices (chunks) are not flattened in one large matrix.
-        # Though for a large number of small chunks, it'd make sense to
-        # flatten all small chunks in one array.
         if 'c' in self.params:
             lambdas, mus = self.means_weight, self.means_prior
             centered_means = self.means_ - mus
@@ -1011,12 +1016,7 @@ class GMMHMM(_BaseHMM):
                 nus = self.covars_weight
 
                 c_n = psis_t + lambdas[:, :, None, None] * centered_means_dots
-                for post_comp_mix, samples in zip(stats['post_comp_mix'],
-                                                  stats['samples']):
-                    centered = samples[:, None, None, :] - means_before_update
-                    centered_dots = outer_f(centered)
-                    c_n += np.einsum('ijk,ijklm->jklm', post_comp_mix,
-                                     centered_dots)
+                c_n += stats['c_n']
                 c_d = (
                     stats['post_mix_sum'] + 1 + nus + nf + 1
                 )[:, :, None, None]
@@ -1027,12 +1027,7 @@ class GMMHMM(_BaseHMM):
                 centered_means2 = centered_means ** 2
 
                 c_n = lambdas[:, :, None] * centered_means2 + 2 * betas
-                for post_comp_mix, samples in zip(stats['post_comp_mix'],
-                                                  stats['samples']):
-                    centered = samples[:, None, None, :] - means_before_update
-                    centered2 = np.square(centered, out=centered)  # reuse
-                    c_n += np.einsum('ijk,ijkl->jkl', post_comp_mix, centered2)
-
+                c_n += stats['c_n']
                 c_d = stats['post_mix_sum'][:, :, None] + 1 + 2 * (alphas + 1)
 
             elif self.covariance_type == 'spherical':
@@ -1044,13 +1039,7 @@ class GMMHMM(_BaseHMM):
                 betas = self.covars_weight
 
                 c_n = lambdas * centered_means_norm2 + 2 * betas
-                for post_comp_mix, samples in zip(stats['post_comp_mix'],
-                                                  stats['samples']):
-                    centered = samples[:, None, None, :] - means_before_update
-                    centered_norm = norm_last(centered)
-                    c_n += np.einsum('ijk,ijk->jk', post_comp_mix,
-                                     centered_norm)
-
+                c_n += stats['c_n']
                 c_d = nf * (stats['post_mix_sum'] + 1) + 2 * (alphas + 1)
 
             elif self.covariance_type == 'tied':
@@ -1059,15 +1048,9 @@ class GMMHMM(_BaseHMM):
                 psis_t = np.transpose(self.covars_prior, axes=(0, 2, 1))
                 nus = self.covars_weight
 
-                c_n = np.einsum('ij,ijkl->ikl', lambdas, centered_means_dots) \
-                      + psis_t
-                for post_comp_mix, samples in zip(stats['post_comp_mix'],
-                                                  stats['samples']):
-                    centered = samples[:, None, None, :] - means_before_update
-                    centered_dots = outer_f(centered)
-                    c_n += np.einsum('ijk,ijklm->jlm', post_comp_mix,
-                                     centered_dots)
-
+                c_n = np.einsum('ij,ijkl->ikl',
+                                lambdas, centered_means_dots) + psis_t
+                c_n += stats['c_n']
                 c_d = (stats['post_sum'] + nm + nus + nf + 1)[:, None, None]
 
             self.covars_ = c_n / c_d


### PR DESCRIPTION
This PR completes https://github.com/hmmlearn/hmmlearn/pull/437
The for-loops introduced in the above-mentioned PR were an intermediate step that shed the light on how we can get rid of storing `post_comp_mix` in the stats. Now, these for-loops are removed, and the logic of computing `c_n` is moved to `_accumulate_sufficient_statistics`.
Finally, an old FIXME is resolved.