### PR TITLE
[ENH, MRG] Add emissionprob_prior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Next
 ----
 
 - The ``PoissonHMM`` class was added with an example use case.
+- For ``MultinomialHMM``, parameters after ``transmat_prior`` are now
+  keyword-only.
 
 Version 0.2.7
 -------------

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -360,8 +360,7 @@ class MultinomialHMM(BaseHMM):
     MultinomialHMM(algorithm='viterbi',...
     """
 
-    # TODO: accept the prior on emissionprob_ for consistency.
-    def __init__(self, n_components=1,
+    def __init__(self, n_components=1, emissionprob_prior=None,
                  startprob_prior=1.0, transmat_prior=1.0,
                  algorithm="viterbi", random_state=None,
                  n_iter=10, tol=1e-2, verbose=False,
@@ -372,6 +371,9 @@ class MultinomialHMM(BaseHMM):
         ----------
         n_components : int
             Number of states.
+
+        emissionprob_prior : array, shape (n_components, n_features), optional
+            The prior on the emission parameters for each state.
 
         startprob_prior : array, shape (n_components, ), optional
             Parameters of the Dirichlet prior distribution for
@@ -418,6 +420,7 @@ class MultinomialHMM(BaseHMM):
                          n_iter=n_iter, tol=tol, verbose=verbose,
                          params=params, init_params=init_params,
                          implementation=implementation)
+        self.emissionprob_prior = emissionprob_prior
 
     score_samples, score, decode, predict, predict_proba, sample, fit = map(
         _multinomialhmm_fix_docstring_shape, [
@@ -444,9 +447,12 @@ class MultinomialHMM(BaseHMM):
         super()._init(X)
         self.random_state = check_random_state(self.random_state)
 
-        if 'e' in self.init_params:
-            self.emissionprob_ = self.random_state \
-                .rand(self.n_components, self.n_features)
+        if self._needs_init('e', 'emissionprob_'):
+            if self.emissionprob_prior is None:
+                self.emissionprob_ = self.random_state.rand(
+                    self.n_components, self.n_features)
+            else:
+                self.emissionprob_ = self.emissionprob_prior
             normalize(self.emissionprob_, axis=1)
 
     def _check(self):

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -491,8 +491,8 @@ class MultinomialHMM(BaseHMM):
         super()._do_mstep(stats)
         if 'e' in self.params:
             self.emissionprob_ = np.maximum(
-                self.emissionprob_prior - 1 + stats['obs'],
-                0) / stats['obs'].sum(axis=1, keepdims=True)
+                self.emissionprob_prior - 1 + stats['obs'], 0)
+            normalize(self.emissionprob_, axis=1)
 
     def _check_and_set_multinomial_n_features(self, X):
         """

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -360,8 +360,8 @@ class MultinomialHMM(BaseHMM):
     MultinomialHMM(algorithm='viterbi',...
     """
 
-    def __init__(self, n_components=1, emissionprob_prior=1.0,
-                 startprob_prior=1.0, transmat_prior=1.0,
+    def __init__(self, n_components=1, startprob_prior=1.0,
+                 transmat_prior=1.0, *, emissionprob_prior=1.0,
                  algorithm="viterbi", random_state=None,
                  n_iter=10, tol=1e-2, verbose=False,
                  params="ste", init_params="ste",
@@ -372,10 +372,6 @@ class MultinomialHMM(BaseHMM):
         n_components : int
             Number of states.
 
-        emissionprob_prior : array, shape (n_components, n_features), optional
-            Parameters of the Dirichlet prior distribution for
-            :attr:`emissionprob_`.
-
         startprob_prior : array, shape (n_components, ), optional
             Parameters of the Dirichlet prior distribution for
             :attr:`startprob_`.
@@ -383,6 +379,10 @@ class MultinomialHMM(BaseHMM):
         transmat_prior : array, shape (n_components, n_components), optional
             Parameters of the Dirichlet prior distribution for each row
             of the transition probabilities :attr:`transmat_`.
+
+        emissionprob_prior : array, shape (n_components, n_features), optional
+            Parameters of the Dirichlet prior distribution for
+            :attr:`emissionprob_`.
 
         algorithm : {"viterbi", "map"}, optional
             Decoder algorithm.

--- a/lib/hmmlearn/tests/test_multinomial_hmm.py
+++ b/lib/hmmlearn/tests/test_multinomial_hmm.py
@@ -138,6 +138,15 @@ class TestMultinomailHMM:
 
         assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
+        # check with emissionprob_prior
+        emissionprob_prior = np.array([[0.3, 0.2, 0.5],
+                                       [0.5, 0.3, 0.2]])
+        h = hmm.MultinomialHMM(
+            self.n_components, params=params, init_params=params,
+            emissionprob_prior=emissionprob_prior)
+        h._init(X)
+        assert_allclose(h.emissionprob_, emissionprob_prior)
+
     @pytest.mark.parametrize("implementation", ["scaling", "log"])
     def test__check_and_set_multinomial_n_features(self, implementation):
         h = self.new_hmm(implementation)

--- a/lib/hmmlearn/tests/test_multinomial_hmm.py
+++ b/lib/hmmlearn/tests/test_multinomial_hmm.py
@@ -138,15 +138,6 @@ class TestMultinomailHMM:
 
         assert_log_likelihood_increasing(h, X, lengths, n_iter)
 
-        # check with emissionprob_prior
-        emissionprob_prior = np.array([[0.3, 0.2, 0.5],
-                                       [0.5, 0.3, 0.2]])
-        h = hmm.MultinomialHMM(
-            self.n_components, params=params, init_params=params,
-            emissionprob_prior=emissionprob_prior)
-        h._init(X)
-        assert_allclose(h.emissionprob_, emissionprob_prior)
-
     @pytest.mark.parametrize("implementation", ["scaling", "log"])
     def test__check_and_set_multinomial_n_features(self, implementation):
         h = self.new_hmm(implementation)


### PR DESCRIPTION
This implements a to do, allowing the user to pass an `emissionprob_prior` for consistency.