### PR TITLE
[MAINT, MRG] Fix prior for PoissonHMM

### DIFF
--- a/examples/plot_poisson_hmm.py
+++ b/examples/plot_poisson_hmm.py
@@ -45,10 +45,10 @@ fig.show()
 scores = list()
 models = list()
 for n_components in range(1, 5):
-    for idx in range(10):
+    for idx in range(10):  # ten different random starting states
         # define our hidden Markov model
         model = hmm.PoissonHMM(n_components=n_components, random_state=idx,
-                               n_iter=100)
+                               n_iter=10)
         model.fit(earthquakes[:, None])
         models.append(model)
         scores.append(model.score(earthquakes[:, None]))

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -1211,10 +1211,11 @@ class PoissonHMM(BaseHMM):
             # section 3.2
             # https://vioshyvo.github.io/Bayesian_inference
             alphas, betas = self.lambdas_prior, self.lambdas_weight
+            n = stats['post'].sum()
+            y_bar = stats['obs'] / stats['post'][:, None]
             # the same as kappa notation (more intuitive) but avoids divide by
             # 0, where:
             # kappas = betas / (betas + stats['post'][:, None])
             # self.lambdas_ = \
             #     kappas * (alphas / betas) + (1 - kappas) * stats['obs']
-            self.lambdas_ = \
-                (alphas + stats['obs']) / (betas + stats['post'][:, None])
+            self.lambdas_ = (alphas + n * y_bar) / (betas + n)

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -1191,7 +1191,6 @@ class PoissonHMM(BaseHMM):
 
     def _initialize_sufficient_statistics(self):
         stats = super()._initialize_sufficient_statistics()
-        stats['nsamples'] = 0
         stats['post'] = np.zeros(self.n_components)
         stats['obs'] = np.zeros((self.n_components, self.n_features))
         return stats
@@ -1201,7 +1200,6 @@ class PoissonHMM(BaseHMM):
         super()._accumulate_sufficient_statistics(
             stats, obs, lattice, posteriors, fwdlattice, bwdlattice)
         if 'l' in self.params:
-            stats['nsamples'] += obs.shape[0]
             stats['post'] += posteriors.sum(axis=0)
             stats['obs'] += np.dot(posteriors.T, obs)
 
@@ -1213,7 +1211,10 @@ class PoissonHMM(BaseHMM):
             # section 3.2
             # https://vioshyvo.github.io/Bayesian_inference
             alphas, betas = self.lambdas_prior, self.lambdas_weight
-            n = stats['nsamples']
-            kappas = betas / (betas + n)
-            y_bar = stats['obs'] / stats['post'][:, None]
-            self.lambdas_ = kappas * (alphas / betas) + (1 - kappas) * y_bar
+            # the same as kappa notation (more intuitive) but avoids divide by
+            # 0, where:
+            # kappas = betas / (betas + stats['post'][:, None])
+            # self.lambdas_ = \
+            #     kappas * (alphas / betas) + (1 - kappas) * stats['obs']
+            self.lambdas_ = \
+                (alphas + stats['obs']) / (betas + stats['post'][:, None])


### PR DESCRIPTION
Fixes https://github.com/hmmlearn/hmmlearn/issues/469. Cleans up https://github.com/hmmlearn/hmmlearn/pull/468.

This test script from a prior commit is a good sanity check too.

```
import numpy as np
import matplotlib.pyplot as plt

from hmmlearn import hmm

# Prepare parameters for a 3-components HMM
# Initial population probability
startprob = np.array([0.6, 0.3, 0.1])
# The transition matrix
transmat = np.array([[0.1, 0.2, 0.7],
                     [0.3, 0.5, 0.2],
                     [0.5, 0.5, 0.0]])
# The means of each component
lambdas = np.array([[17.4, 22.1],
                    [35.3, 60.8],
                    [50.1, 12.9]])

# Build an HMM instance and set parameters
gen_model = hmm.PoissonHMM(n_components=3, random_state=99)

# Instead of fitting it from the data, we directly set the estimated
# parameters, the means and covariance of the components
gen_model.startprob_ = startprob
gen_model.transmat_ = transmat
gen_model.lambdas_ = lambdas

# Generate samples
X, Z = gen_model.sample(500)

# Plot the sampled data
fig, ax = plt.subplots()
ax.plot(X[:, 0], X[:, 1], ".-", label="observations", ms=6,
        mfc="orange", alpha=0.7, linewidth=0.1)

# Indicate the component numbers
for i, m in enumerate(lambdas):
    ax.text(m[0], m[1], 'Component %i' % (i + 1),
            size=17, horizontalalignment='center',
            bbox=dict(alpha=.7, facecolor='w'))
ax.legend(loc='best')
fig.show()

# %%
# Now, let's ensure we can recover our parameters.

scores = list()
models = list()
for n_components in range(1, 5):
    for idx in range(10):   # different random seeds
        # define our hidden Markov model
        model = hmm.PoissonHMM(n_components=3, random_state=idx)
        model.fit(X[:X.shape[0] // 2])  # 50/50 train/validate
        models.append(model)
        scores.append(model.score(X[X.shape[0] // 2:]))
        print(f'Converged: {model.monitor_.converged}'
              f'\tScore: {scores[-1]}')

# get the best model
model = models[np.argmax(scores)]
print(f'The best model had a score of {max(scores)}')

# use the Viterbi algorithm to predict the most likely sequence of states
# given the model
states = model.predict(X)

# %%
# Let's plot our states compared to those generated and our transition matrix
# to get a sense of our model. We can see that the recovered states follow
# the same path as the generated states, just with the identities of the
# states transposed (i.e. instead of following a square as in the first
# figure, the nodes are switch around but this does not change the basic
# pattern). The same is true for the transition matrix.

# plot model states over time
fig, ax = plt.subplots()
ax.plot(Z, states)
ax.set_title('States compared to generated')
ax.set_xlabel('Generated State')
ax.set_ylabel('Recovered State')
fig.show()

# plot the transition matrix
fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 5))
ax1.imshow(gen_model.transmat_, aspect='auto', cmap='spring')
ax1.set_title('Generated Transition Matrix')
ax2.imshow(model.transmat_, aspect='auto', cmap='spring')
ax2.set_title('Recovered Transition Matrix')
for ax in (ax1, ax2):
    ax.set_xlabel('State To')
    ax.set_ylabel('State From')

fig.tight_layout()
fig.show()
```

I also realized you could get `n` from the sum of the posterior since each row adds up to 1 and there are `n_samples` number of columns so that's nice to simplify a bit.

I feel much better about this implementation. If you pass `alpha=0` and `beta=0` you'll just get `obs` / `post` which I think is important to be able to not enforce a gamma-distributed prior.