### PR TITLE
Allow setting n_features for Categorical and VariationalCategorical HMMs

### DIFF
--- a/lib/hmmlearn/_emissions.py
+++ b/lib/hmmlearn/_emissions.py
@@ -19,7 +19,7 @@ class BaseCategoricalHMM(_AbstractHMM):
             raise ValueError("Symbols should be integers")
         if X.min() < 0:
             raise ValueError("Symbols should be nonnegative")
-        if hasattr(self, "n_features"):
+        if self.n_features is not None:
             if self.n_features - 1 < X.max():
                 raise ValueError(
                     f"Largest symbol is {X.max()} but the model only emits "

--- a/lib/hmmlearn/hmm.py
+++ b/lib/hmmlearn/hmm.py
@@ -78,9 +78,9 @@ class CategoricalHMM(_emissions.BaseCategoricalHMM, BaseHMM):
 
     def __init__(self, n_components=1, startprob_prior=1.0,
                  transmat_prior=1.0, *, emissionprob_prior=1.0,
-                 algorithm="viterbi", random_state=None,
-                 n_iter=10, tol=1e-2, verbose=False,
-                 params="ste", init_params="ste",
+                 n_features=None, algorithm="viterbi",
+                 random_state=None, n_iter=10, tol=1e-2,
+                 verbose=False, params="ste", init_params="ste",
                  implementation="log"):
         """
         Parameters
@@ -99,6 +99,10 @@ class CategoricalHMM(_emissions.BaseCategoricalHMM, BaseHMM):
         emissionprob_prior : array, shape (n_components, n_features), optional
             Parameters of the Dirichlet prior distribution for
             :attr:`emissionprob_`.
+
+        n_features: int, optional
+            The number of categorical symbols in the HMM.  Will be inferred
+            from the data if not set.
 
         algorithm : {"viterbi", "map"}, optional
             Decoder algorithm.
@@ -138,6 +142,7 @@ class CategoricalHMM(_emissions.BaseCategoricalHMM, BaseHMM):
                          params=params, init_params=init_params,
                          implementation=implementation)
         self.emissionprob_prior = emissionprob_prior
+        self.n_features = n_features
 
     score_samples, score, decode, predict, predict_proba, sample, fit = map(
         _categoricalhmm_fix_docstring_shape, [
@@ -164,12 +169,13 @@ class CategoricalHMM(_emissions.BaseCategoricalHMM, BaseHMM):
         super()._check()
 
         self.emissionprob_ = np.atleast_2d(self.emissionprob_)
-        n_features = getattr(self, "n_features", self.emissionprob_.shape[1])
-        if self.emissionprob_.shape != (self.n_components, n_features):
+        if self.n_features is None:
+            self.n_features = self.emissionprob_.shape[1]
+        if self.emissionprob_.shape != (self.n_components, self.n_features):
             raise ValueError(
-                "emissionprob_ must have shape (n_components, n_features)")
+                f"emissionprob_ must have shape"
+                f"({self.n_components}, {self.n_features})")
         self._check_sum_1("emissionprob_")
-        self.n_features = n_features
 
     def _do_mstep(self, stats):
         super()._do_mstep(stats)

--- a/lib/hmmlearn/tests/test_categorical_hmm.py
+++ b/lib/hmmlearn/tests/test_categorical_hmm.py
@@ -71,6 +71,25 @@ class TestCategoricalHMM:
         return h
 
     @pytest.mark.parametrize("implementation", ["scaling", "log"])
+    def test_n_features(self, implementation):
+        sequences, _ = self.new_hmm(implementation).sample(500)
+        # set n_features
+        model = hmm.CategoricalHMM(
+            n_components=2, implementation=implementation)
+
+        assert_log_likelihood_increasing(model, sequences, [500], 10)
+        assert model.n_features == 3
+
+        # Respect n_features
+        model = hmm.CategoricalHMM(
+            n_components=2,
+            implementation=implementation,
+            n_features=5)
+
+        assert_log_likelihood_increasing(model, sequences, [500], 10)
+        assert model.n_features == 5
+
+    @pytest.mark.parametrize("implementation", ["scaling", "log"])
     def test_attributes(self, implementation):
         with pytest.raises(ValueError):
             h = self.new_hmm(implementation)

--- a/lib/hmmlearn/tests/test_variational_categorical.py
+++ b/lib/hmmlearn/tests/test_variational_categorical.py
@@ -75,6 +75,18 @@ class TestVariationalCategorical:
     def test_n_features(self, implementation):
 
         sequences, lengths = self.get_from_one_beal(7, 100, None)
+        # Learn n_Features
+        model = vhmm.VariationalCategoricalHMM(
+            4, implementation=implementation)
+        assert_log_likelihood_increasing(model, sequences, lengths, 10)
+        assert model.n_features == 3
+        # Respect n_features
+        model = vhmm.VariationalCategoricalHMM(
+            4, implementation=implementation, n_features=5)
+
+        assert_log_likelihood_increasing(model, sequences, lengths, 10)
+        assert model.n_features == 5
+
         # Too few features
         with pytest.raises(ValueError):
             model = vhmm.VariationalCategoricalHMM(

--- a/lib/hmmlearn/vhmm.py
+++ b/lib/hmmlearn/vhmm.py
@@ -59,7 +59,7 @@ class VariationalCategoricalHMM(BaseCategoricalHMM, VariationalBaseHMM):
 
     def __init__(self, n_components=1,
                  startprob_prior=None, transmat_prior=None,
-                 emissionprob_prior=None,
+                 emissionprob_prior=None, n_features=None,
                  algorithm="viterbi", random_state=None,
                  n_iter=100, tol=1e-6, verbose=False,
                  params="ste", init_params="ste",
@@ -81,6 +81,10 @@ class VariationalCategoricalHMM(BaseCategoricalHMM, VariationalBaseHMM):
         emissionprob_prior : array, shape (n_components, n_features), optional
             Parameters of the Dirichlet prior distribution for
             :attr:`emissionprob_`.
+
+        n_features: int, optional
+            The number of categorical symbols in the HMM.  Will be inferred
+            from the data if not set.
 
         algorithm : {"viterbi", "map"}, optional
             Decoder algorithm.
@@ -120,6 +124,7 @@ class VariationalCategoricalHMM(BaseCategoricalHMM, VariationalBaseHMM):
             implementation=implementation
         )
         self.emissionprob_prior = emissionprob_prior
+        self.n_features = n_features
 
     def _init(self, X, lengths):
         """
@@ -176,12 +181,13 @@ class VariationalCategoricalHMM(BaseCategoricalHMM, VariationalBaseHMM):
             raise ValueError(
                 "emissionprob_prior_ and emissionprob_posterior_must"
                 "have shape (n_components, n_features)")
-        n_features = getattr(self, "n_features",
-                             self.emissionprob_posterior_.shape[1])
+        if self.n_features is None:
+            self.n_features = self.emissionprob_posterior_.shape[1]
         if (self.emissionprob_posterior_.shape
-                != (self.n_components, n_features)):
+                != (self.n_components, self.n_features)):
             raise ValueError(
-                "emissionprob_ must have shape (n_components, n_features)")
+                f"emissionprob_ must have shape"
+                f"({self.n_components}, {self.n_features})")
 
     def _compute_subnorm_log_likelihood(self, X):
         return self.emissionprob_log_subnorm_[:, np.concatenate(X)].T


### PR DESCRIPTION
I'm porting some code from my thesis to cluster HMMs.  In that algorithm I train a model on each sequence - some sequences may not contain the full set of emissions symbols, so it is necessary to specify the shape of the emissions distribution during HMM setup.