### PR TITLE
Make the 'rows must sum to 1' phrasing clearer

### DIFF
--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -547,7 +547,7 @@ class _AbstractHMM(BaseEstimator):
         if not np.allclose(s, 1):
             raise ValueError(
                 f"{name} must sum to 1 (got {s:.4f})" if s.ndim == 0 else
-                f"{name} rows must sum to 1 (got {s})" if s.ndim == 1 else
+                f"{name} rows must sum to 1 (got row sums of {s})" if s.ndim == 1 else
                 "Expected 1D or 2D array")
 
     def _check(self):
@@ -930,7 +930,7 @@ class BaseHMM(_AbstractHMM):
         if not np.allclose(s, 1):
             raise ValueError(
                 f"{name} must sum to 1 (got {s:.4f})" if s.ndim == 0 else
-                f"{name} rows must sum to 1 (got {s})" if s.ndim == 1 else
+                f"{name} rows must sum to 1 (got row sums of {s})" if s.ndim == 1 else
                 "Expected 1D or 2D array")
 
     def _check(self):
@@ -1001,6 +1001,7 @@ class BaseHMM(_AbstractHMM):
         """
         n_params = sum(self._get_n_fit_scalars_per_param().values())
         return -2 * self.score(X, lengths=lengths) + n_params * np.log(len(X))
+
 
 _BaseHMM = BaseHMM  # Backcompat name, will be deprecated in the future.
 

--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -546,9 +546,11 @@ class _AbstractHMM(BaseEstimator):
         s = getattr(self, name).sum(axis=-1)
         if not np.allclose(s, 1):
             raise ValueError(
-                f"{name} must sum to 1 (got {s:.4f})" if s.ndim == 0 else
-                f"{name} rows must sum to 1 (got row sums of {s})" if s.ndim == 1 else
-                "Expected 1D or 2D array")
+                f"{name} must sum to 1 (got {s:.4f})"
+                if s.ndim == 0
+                else f"{name} rows must sum to 1 (got row sums of {s})"
+                    if s.ndim == 1
+                    else "Expected 1D or 2D array")
 
     def _check(self):
         """
@@ -929,9 +931,11 @@ class BaseHMM(_AbstractHMM):
         s = getattr(self, name).sum(axis=-1)
         if not np.allclose(s, 1):
             raise ValueError(
-                f"{name} must sum to 1 (got {s:.4f})" if s.ndim == 0 else
-                f"{name} rows must sum to 1 (got row sums of {s})" if s.ndim == 1 else
-                "Expected 1D or 2D array")
+                f"{name} must sum to 1 (got {s:.4f})"
+                if s.ndim == 0
+                else f"{name} rows must sum to 1 (got row sums of {s})"
+                    if s.ndim == 1
+                    else "Expected 1D or 2D array")
 
     def _check(self):
         """


### PR DESCRIPTION
I was quite confused when I first saw this error:

```
Value error: transmat_ rows must sum to 1 (got [1. 1. 1. 1. 1. 1. 1. 1. 0. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.])
```

I wasn't sure where that vector of numbers had come from (I was new to HMMs and didn't realise it was the sum of the rows.

This little change just updates the wording a bit to make it clear that the vector shown is indeed the sums of each row.


```
Value error: transmat_ rows must sum to 1 (got row sums of [1. 1. 1. 1. 1. 1. 1. 1. 0. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.])
```