### PR TITLE
hack for GIL bug

### DIFF
--- a/ext/_hmmc.cpp
+++ b/ext/_hmmc.cpp
@@ -1,3 +1,4 @@
+#define PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <cfenv>


### PR DESCRIPTION
In Debian, we need this patch to allow the tests to pass, otherwise 202 of them fail.

Here's a full log. I can also create a `Dockerfile` demonstrating the bug, for the curious.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082695

Sample error
```
    def _fit_scaling(self, X):
        frameprob = self._compute_subnorm_likelihood(X)
>       logprob, fwdlattice, scaling_factors = _hmmc.forward_scaling(
            self.startprob_subnorm_, self.transmat_subnorm_, frameprob)
E       RuntimeError: pybind11::handle::inc_ref() PyGILState_Check() failure.

hmmlearn/base.py:1103: RuntimeError
----------------------------- Captured stderr call -----------------------------
pybind11::handle::inc_ref() is being called while the GIL is either not held or invalid. Please see https://pybind11.readthedocs.io/en/stable/advanced/misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.
If you are convinced there is no bug in your code, you can #define PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF to disable this check. In that case you have to ensure this #define is consistently used for all translation units linked into a given pybind11 extension, otherwise there will be ODR violations. The failing pybind11::handle::inc_ref() call was triggered on a numpy.ndarray object.
```